### PR TITLE
chore(apm): refresh apm.lock.yaml

### DIFF
--- a/.agents/skills/renri/SKILL.md
+++ b/.agents/skills/renri/SKILL.md
@@ -66,6 +66,13 @@ renri remove fix/review-feedback   # or: renri prune (after main pulls)
   matches an existing branch / bookmark, attaches to it instead.
   **If `<name>` is omitted**, prompts interactively unless
   `--non-interactive` is set.
+  - `--from <ref>` forks the new branch off `<ref>` instead of the cwd
+    HEAD (commit / branch / bookmark / tag / revset). Pass the flag with
+    no value to pick from a fuzzy list of local refs. When `<ref>` names
+    a **remote-tracking** ref (`main@origin` for jj, `origin/main` for
+    git), `add` runs a `fetch` first so the worktree forks off the
+    current upstream tip rather than a stale locally-cached one. Pass
+    `--no-fetch` to skip that fetch (offline, or to pin the cached ref).
 - `renri list` (alias `ls`) — show all worktrees with name, path,
   branch, and flags.
 - `renri cd <name>` — print the absolute path of a worktree on stdout.

--- a/.claude/skills/renri/SKILL.md
+++ b/.claude/skills/renri/SKILL.md
@@ -66,6 +66,13 @@ renri remove fix/review-feedback   # or: renri prune (after main pulls)
   matches an existing branch / bookmark, attaches to it instead.
   **If `<name>` is omitted**, prompts interactively unless
   `--non-interactive` is set.
+  - `--from <ref>` forks the new branch off `<ref>` instead of the cwd
+    HEAD (commit / branch / bookmark / tag / revset). Pass the flag with
+    no value to pick from a fuzzy list of local refs. When `<ref>` names
+    a **remote-tracking** ref (`main@origin` for jj, `origin/main` for
+    git), `add` runs a `fetch` first so the worktree forks off the
+    current upstream tip rather than a stale locally-cached one. Pass
+    `--no-fetch` to skip that fetch (offline, or to pin the cached ref).
 - `renri list` (alias `ls`) — show all worktrees with name, path,
   branch, and flags.
 - `renri cd <name>` — print the absolute path of a worktree on stdout.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,13 +1,57 @@
 lockfile_version: '1'
-generated_at: '2026-05-10T04:14:04.730041+00:00'
-apm_version: 0.12.1
+generated_at: '2026-08-17T04:19:23.249418+00:00'
+apm_version: 0.28.0
 dependencies:
 - repo_url: yukimemi/renri
+  name: renri
   host: github.com
-  resolved_commit: 50c3ee2f9fadbe726fbe695cf1846b970feb62f0
+  resolved_commit: a94b823fb1ba92fa078431bfe27f9247fadcf13e
   resolved_ref: main
+  version: 0.1.17
   package_type: apm_package
   deployed_files:
   - .agents/skills/renri
+  - .agents/skills/renri/SKILL.md
   - .claude/skills/renri
-  content_hash: sha256:64f3babacb8a6d1fad43275d5617548239bf70762b108f94ec1865016cef6a96
+  - .claude/skills/renri/SKILL.md
+  deployed_file_hashes:
+    .agents/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
+    .claude/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
+  content_hash: sha256:ddea123a9396f5958bce55a90df22c4af9db20f1d31208bee34a0f5f2659ec8d
+deployments:
+- kind: project-relative
+  target: claude
+  value: .claude/skills/renri
+  runtime: null
+  scope: project
+  owners:
+  - yukimemi/renri
+  active_owner: yukimemi/renri
+  content_hash: null
+- kind: project-relative
+  target: claude
+  value: .claude/skills/renri/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - yukimemi/renri
+  active_owner: yukimemi/renri
+  content_hash: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/renri
+  runtime: null
+  scope: project
+  owners:
+  - yukimemi/renri
+  active_owner: yukimemi/renri
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/renri/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - yukimemi/renri
+  active_owner: yukimemi/renri
+  content_hash: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6


### PR DESCRIPTION
Automated `apm install --update` (weekly schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the `renri add --from <ref>` option.
  - Clarified supported reference types and fuzzy selection when no reference is provided.
  - Explained automatic fetching of remote-tracking references and the `--no-fetch` override.

- **Chores**
  - Updated project tooling metadata to reflect the latest supported release information and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->